### PR TITLE
Fix code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,19 @@ const mongoose = require('mongoose');
 const bodyParser = require('body-parser');
 const cors = require('cors');
 const path = require('path');
+const RateLimit = require('express-rate-limit');
 
 const app = express();
 app.use(bodyParser.json());
 app.use(cors());
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+// apply rate limiter to all requests
+app.use(limiter);
 
 mongoose.connect('mongodb://localhost:27017/parking', { useNewUrlParser: true, useUnifiedTopology: true });
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "body-parser": "^1.20.3",
     "express": "^4.21.1",
-    "mongoose": "^8.7.3"
+    "mongoose": "^8.7.3",
+    "express-rate-limit": "^7.4.1"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/akaday/automated-parking/security/code-scanning/1](https://github.com/akaday/automated-parking/security/code-scanning/1)

To fix the problem, we need to introduce a rate-limiting middleware to the Express application. The `express-rate-limit` package is a well-known library for this purpose. We will configure it to limit the number of requests to a reasonable number per time window and apply it to all routes, including the one that serves the static file.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `index.js` file.
3. Configure the rate limiter with appropriate settings (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to the Express application using `app.use`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
