### PR TITLE
Fix code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/routes/parking.js
+++ b/routes/parking.js
@@ -17,8 +17,18 @@ router.get('/spots', async (req, res) => {
   try {
     const { location, size } = req.query;
     const query = {};
-    if (location) query.location = location;
-    if (size) query.size = size;
+    if (location) {
+      if (typeof location !== 'string') {
+        return res.status(400).json({ message: 'Invalid location' });
+      }
+      query.location = { $eq: location };
+    }
+    if (size) {
+      if (typeof size !== 'string') {
+        return res.status(400).json({ message: 'Invalid size' });
+      }
+      query.size = { $eq: size };
+    }
     const spots = await ParkingSpot.find(query);
     res.json(spots);
   } catch (err) {


### PR DESCRIPTION
Fixes [https://github.com/akaday/automated-parking/security/code-scanning/3](https://github.com/akaday/automated-parking/security/code-scanning/3)

To fix the problem, we need to ensure that the user-provided data is interpreted as literal values and not as query objects. This can be achieved by using the `$eq` operator in the MongoDB query to ensure that the input is treated as a literal value. Additionally, we should validate the input to ensure it is of the expected type.

- Modify the query construction to use the `$eq` operator for `location` and `size`.
- Add input validation to ensure that `location` and `size` are strings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
