### PR TITLE
Refactor failed server port 5002

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ app.use(limiter);
 
 mongoose.connect('mongodb://localhost:27017/parking', { useNewUrlParser: true, useUnifiedTopology: true });
 
-const port = process.env.PORT || 5002;
+const port = process.env.PORT || 5000;
 
 const parkingRoutes = require('./routes/parking');
 app.use('/api', parkingRoutes);


### PR DESCRIPTION
Change the default server port from 5002 to 5000 in `index.js`.

* Update the `port` variable definition to use 5000 as the default port.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/automated-parking?shareId=51b3f5c5-ed76-471f-9e8f-cd5931fe8267).